### PR TITLE
Feat/event

### DIFF
--- a/components/event/sections/cta.tsx
+++ b/components/event/sections/cta.tsx
@@ -5,6 +5,7 @@ import { LuLinkedin } from "react-icons/lu";
 import { FaInstagram, FaTelegram } from "react-icons/fa";
 import { BsTwitterX } from "react-icons/bs";
 import { motion } from "motion/react";
+import { useRouter } from "next/navigation";
 
 const socialLinks = [
   {
@@ -52,6 +53,7 @@ const aboutLinks = [
 ];
 
 export default function BuildathonCTA() {
+const router = useRouter();
   return (
     <section
       className="w-full min-h-screen h-auto bg-[#8D2BDC]"
@@ -93,6 +95,7 @@ export default function BuildathonCTA() {
                 size="large"
                 shadowOffset={{ x: -3, y: 4 }}
                 hasArrow
+          onClick={() => router.push("/event/registration")}
               />
             </div>
             <div className="w-full">

--- a/components/event/sections/hero.tsx
+++ b/components/event/sections/hero.tsx
@@ -290,8 +290,10 @@ import React from "react";
 import StackGridButton from "../stack-grid-button";
 import { stats } from "./stats";
 import { motion } from "motion/react";
+import { useRouter } from "next/navigation";
 
 export default function BuildathonHero() {
+const router = useRouter();
   return (
     <section className="w-full h-auto pt-36 lg:pt-64 bg-[url('/assets/events/hero_bg.jpg')] bg-cover bg-center overflow-hidden flex flex-col items-center justify-center relative">
       <motion.div
@@ -339,6 +341,7 @@ export default function BuildathonHero() {
               size="large"
               shadowOffset={{ x: -3, y: 4 }}
               hasArrow
+onClick={()=>router.push("/event/registration")}
             />
           </div>
           <div className="w-full md:w-1/2">


### PR DESCRIPTION
This pull request updates the event CTA and hero sections to make the registration button interactive by navigating users to the registration page when clicked. The main changes involve adding routing logic using Next.js's `useRouter` hook.

Enhancements to registration button functionality:

* Added `useRouter` import from `next/navigation` and initialized the router in both `cta.tsx` and `hero.tsx` components to enable programmatic navigation. [[1]](diffhunk://#diff-12c0a296d1e53b1c793b1adb3b90ca9f647d089d1c5deded02413c954884c8ebR8) [[2]](diffhunk://#diff-c4a28b1f6436b48472f86414ec58dbf2ce4b8cbfefd3dcc466251acc97220618R293-R296) [[3]](diffhunk://#diff-12c0a296d1e53b1c793b1adb3b90ca9f647d089d1c5deded02413c954884c8ebR56) [[4]](diffhunk://#diff-c4a28b1f6436b48472f86414ec58dbf2ce4b8cbfefd3dcc466251acc97220618R293-R296)
* Updated the registration button's `onClick` handler in both `BuildathonCTA` and `BuildathonHero` components to use `router.push("/event/registration")`, ensuring users are redirected to the registration page upon clicking. [[1]](diffhunk://#diff-12c0a296d1e53b1c793b1adb3b90ca9f647d089d1c5deded02413c954884c8ebR98) [[2]](diffhunk://#diff-c4a28b1f6436b48472f86414ec58dbf2ce4b8cbfefd3dcc466251acc97220618R344)